### PR TITLE
[zk-219] Add a shell script to profile mock test

### DIFF
--- a/profile_mock.sh
+++ b/profile_mock.sh
@@ -1,0 +1,9 @@
+export CARGO_PROFILE_RELEASE_DEBUG=true
+
+nohup make mock > mock.out 2>&1 &
+echo "Mock started"
+
+sleep 5
+
+nohup flamegraph -o scoll-zkevm.svg --pid $(pgrep -f "integration-.* test_mock_prove") > flamegraph.out 2>&1 &
+echo "Flamegraph started"


### PR DESCRIPTION
-Changes:
port from scroll-prover/pull/146
its only a script to generate flamegraph, no meaningful logic