### PR TITLE
[zk-221] Use light mode when calculating row usage

### DIFF
--- a/bin/src/mock_testnet.rs
+++ b/bin/src/mock_testnet.rs
@@ -50,7 +50,7 @@ async fn main() {
                         .iter()
                         .map(|b| b.header.gas_used.as_u64())
                         .sum();
-                    let witness_block = block_traces_to_witness_block(&block_traces)?;
+                    let witness_block = block_traces_to_witness_block(&block_traces, false)?;
                     let rows = calculate_row_usage_of_witness_block(&witness_block)?;
                     log::info!(
                         "rows of batch {}(block range {:?} to {:?}):",

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -125,7 +125,7 @@ pub fn chunk_trace_to_witness_block(mut chunk_trace: Vec<BlockTrace>) -> Result<
     // Check if the trace exceeds the circuit capacity.
     check_batch_capacity(&mut chunk_trace)?;
 
-    block_traces_to_witness_block(&chunk_trace)
+    block_traces_to_witness_block(&chunk_trace, false)
 }
 
 // Return the output dir.

--- a/prover/src/zkevm/circuit.rs
+++ b/prover/src/zkevm/circuit.rs
@@ -72,7 +72,7 @@ pub trait TargetCircuit {
     where
         Self: Sized,
     {
-        let witness_block = block_traces_to_witness_block(block_traces)?;
+        let witness_block = block_traces_to_witness_block(block_traces, false)?;
         Self::from_witness_block(&witness_block)
     }
 
@@ -84,7 +84,7 @@ pub trait TargetCircuit {
         Self: Sized;
 
     fn estimate_rows(block_traces: &[BlockTrace]) -> anyhow::Result<usize> {
-        let witness_block = block_traces_to_witness_block(block_traces)?;
+        let witness_block = block_traces_to_witness_block(block_traces, true)?;
         Ok(Self::estimate_rows_from_witness_block(&witness_block))
     }
 

--- a/prover/src/zkevm/circuit/builder.rs
+++ b/prover/src/zkevm/circuit/builder.rs
@@ -27,7 +27,7 @@ pub const SUB_CIRCUIT_NAMES: [&str; 11] = [
 
 // TODO: optimize it later
 pub fn calculate_row_usage_of_trace(block_trace: &BlockTrace) -> Result<Vec<usize>> {
-    let witness_block = block_traces_to_witness_block(std::slice::from_ref(block_trace))?;
+    let witness_block = block_traces_to_witness_block(std::slice::from_ref(block_trace), true)?;
     calculate_row_usage_of_witness_block(&witness_block)
 }
 
@@ -169,7 +169,7 @@ pub fn update_state(
     Ok(())
 }
 
-pub fn block_traces_to_witness_block(block_traces: &[BlockTrace]) -> Result<Block<Fr>> {
+pub fn block_traces_to_witness_block(block_traces: &[BlockTrace], light_mode: bool) -> Result<Block<Fr>> {
     log::debug!(
         "block_traces_to_witness_block, input len {:?}",
         block_traces.len()
@@ -180,8 +180,8 @@ pub fn block_traces_to_witness_block(block_traces: &[BlockTrace]) -> Result<Bloc
         block_traces[0].storage_trace.root_before
     };
     let mut state = ZktrieState::construct(old_root);
-    update_state(&mut state, block_traces, false)?;
-    block_traces_to_witness_block_with_updated_state(block_traces, &mut state, false)
+    update_state(&mut state, block_traces, light_mode)?;
+    block_traces_to_witness_block_with_updated_state(block_traces, &mut state, light_mode)
 }
 
 pub fn block_traces_to_witness_block_with_updated_state(

--- a/prover/src/zkevm/prover.rs
+++ b/prover/src/zkevm/prover.rs
@@ -131,7 +131,7 @@ impl Prover {
             // will return early if the check finds out the trace exceeds the circuit capacity
             check_batch_capacity(&mut block_traces)?;
 
-            let witness_block = block_traces_to_witness_block(&block_traces)?;
+            let witness_block = block_traces_to_witness_block(&block_traces, false)?;
             log::info!(
                 "proving the chunk: {:?}",
                 metric_of_witness_block(&witness_block)

--- a/prover/src/zkevm/prover/mock.rs
+++ b/prover/src/zkevm/prover/mock.rs
@@ -25,7 +25,7 @@ impl Prover {
         let original_block_len = block_traces.len();
         let mut block_traces = block_traces.to_vec();
         check_batch_capacity(&mut block_traces)?;
-        let witness_block = block_traces_to_witness_block(&block_traces)?;
+        let witness_block = block_traces_to_witness_block(&block_traces, false)?;
         log::info!(
             "mock proving batch of len {}, batch metric {:?}",
             original_block_len,


### PR DESCRIPTION
-Change 
Port from scroll-prover/pull/163
Use light mode when calculating row usage
Also truncate batches if MAX_TXS is exceeded. This will happen anyways inside the circuit input building, but truncating earlier means that the final root of the batch will be set correctly.