### PR TITLE
fix: flatten `ChunkProof`

### DIFF
--- a/prover/src/proof/chunk.rs
+++ b/prover/src/proof/chunk.rs
@@ -12,6 +12,7 @@ pub struct ChunkProof {
     pub storage_trace: Vec<u8>,
     #[serde(with = "base64")]
     pub protocol: Vec<u8>,
+    #[serde(flatten)]
     pub proof: Proof,
 }
 


### PR DESCRIPTION
### Summary

After testing, the generated `ChunkProof` is flatten (without nested node `proof`) as:
```
{
  "storage_trace": "eyJyb290Qm ...",
  "protocol": "eyJkb21haW ...",
  "proof": "m9U8cCKb72 ...".
  "instances": "W1tbMTMsMj ...",
  "vk": "AAAAGAAA ..."
}
```

Related scroll commit https://github.com/scroll-tech/scroll/pull/689/commits/d4a89c780abc931ee1ba5994332d0ca2232728a7