### PR TITLE
pk recover for deposit tx may be wrong

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -6,11 +6,20 @@ set -o pipefail
 export RUST_LOG=debug
 #export RUST_LOG=trace
 
+function bridge_tests() {
+	export CHAIN_ID=534351
+	for path in depositERC20.json withdrawERC20.json approveERC20.json depositETH.json withdrawETH.json; do
+		(TRACE_PATH=$(realpath prover/tests/traces/bridge/$path) make mock >/tmp/mock_${path}.log 2>&1) &
+	done
+	wait
+	echo test done
+	grep 'proved' /tmp/mock_*.log
+}
+
 function simple_tests() {
-	for mode in pack sushi multiple nft dao native empty 
-	do
+	for mode in pack sushi multiple nft dao native empty; do
 		#MODE=$mode make mock 2>&1 | tee /tmp/mock_${mode}.log
-		(MODE=$mode make mock > /tmp/mock_${mode}.log 2>&1) &
+		(MODE=$mode make mock >/tmp/mock_${mode}.log 2>&1) &
 	done
 	wait
 	echo test done
@@ -26,5 +35,6 @@ function replace_zkevm_circuits_branch() {
 	git diff */Cargo.toml Cargo.lock
 }
 
-replace_zkevm_circuits_branch
+#replace_zkevm_circuits_branch
 #simple_tests
+bridge_tests


### PR DESCRIPTION
bash utils.rs


inside log of the depositETH and depositERC20 tests,  there is ```2023-08-02T06:01:32.640123306+00:00 ERROR zkevm_circuits::tx_circuit - pk address from sign data 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf does not match the one from tx address 0xc555e7a11cddff67c3477bb5c4d6d26a768c5a64```

worth checking.  


(btw the l1 fee in these traces may not correct.   That is the reason why mock proving fails. Not sure whether it is related to pk recover failure..)