### PR TITLE
fix: tx_type info is lost 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "types",
 ]
 
+[patch.crates-io]
+ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v0.17.0" }
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop"  }
 [patch."https://github.com/privacy-scaling-explorations/poseidon.git"]

--- a/types/src/eth.rs
+++ b/types/src/eth.rs
@@ -90,7 +90,7 @@ impl TransactionTrace {
             v: self.v,
             r: self.r,
             s: self.s,
-            transaction_type: None,
+            transaction_type: Some(U64::from(self.type_ as u64)),
             access_list: None,
             max_priority_fee_per_gas: None,
             max_fee_per_gas: None,


### PR DESCRIPTION
This pr aims to fix two issues.

1. tx_type is not passed downward.
2. we must use own fork of ethers which supports the RLP encoding & decoding of `L1Msg` tx.

This pr and https://github.com/scroll-tech/zkevm-circuits/pull/710 together will fix the https://github.com/scroll-tech/scroll-prover/pull/190 issue.