### PR TITLE
Fix encoded calldata

### DIFF
--- a/prover/src/common/verifier/evm.rs
+++ b/prover/src/common/verifier/evm.rs
@@ -1,11 +1,7 @@
 use super::Verifier;
 use crate::{io::write_file, EvmProof, Proof};
 use halo2_proofs::halo2curves::bn256::{Bn256, Fr};
-use itertools::Itertools;
-use snark_verifier::{
-    pcs::kzg::{Bdfg21, Kzg},
-    util::arithmetic::PrimeField,
-};
+use snark_verifier::pcs::kzg::{Bdfg21, Kzg};
 use snark_verifier_sdk::{gen_evm_verifier, verify_evm_proof, CircuitExt};
 use std::{path::PathBuf, str::FromStr};
 
@@ -26,20 +22,6 @@ impl<C: CircuitExt<Fr>> Verifier<C> {
         // Dump bytecode.
         let mut output_dir = PathBuf::from_str(output_dir).unwrap();
         write_file(&mut output_dir, "evm_verifier.bin", &deployment_code);
-
-        // Dump public input data.
-        let pi_data: Vec<_> = evm_proof
-            .proof
-            .instances()
-            .iter()
-            .flatten()
-            .flat_map(|value| value.to_repr().as_ref().iter().rev().cloned().collect_vec())
-            .collect();
-        write_file(&mut output_dir, "evm_pi_data.data", &pi_data);
-
-        // Dump proof.
-        let proof_data = evm_proof.proof.proof().to_vec();
-        write_file(&mut output_dir, "evm_proof.data", &proof_data);
 
         let success = self.verify_evm_proof(deployment_code, &evm_proof.proof);
         assert!(success);

--- a/prover/src/proof.rs
+++ b/prover/src/proof.rs
@@ -1,4 +1,4 @@
-use crate::io::{deserialize_fr, deserialize_vk, serialize_fr_vec, serialize_vk, write_file};
+use crate::io::{deserialize_fr, deserialize_vk, serialize_fr, serialize_vk, write_file};
 use anyhow::{bail, Result};
 use halo2_proofs::{
     halo2curves::bn256::{Fr, G1Affine},
@@ -73,7 +73,7 @@ impl Proof {
         let instance: Vec<Fr> = self
             .instances
             .chunks(32)
-            .map(|bytes| deserialize_fr(bytes.to_vec()))
+            .map(|bytes| deserialize_fr(bytes.iter().rev().cloned().collect()))
             .collect();
 
         vec![instance]
@@ -164,7 +164,10 @@ fn dummy_protocol() -> Protocol<G1Affine> {
 }
 
 fn serialize_instance(instance: &[Fr]) -> Vec<u8> {
-    let bytes: Vec<_> = serialize_fr_vec(instance).into_iter().flatten().collect();
+    let bytes: Vec<_> = instance
+        .iter()
+        .flat_map(|value| serialize_fr(value).into_iter().rev())
+        .collect();
     assert_eq!(bytes.len() % 32, 0);
 
     bytes

--- a/prover/src/proof/batch.rs
+++ b/prover/src/proof/batch.rs
@@ -2,6 +2,7 @@ use super::{dump_as_json, dump_data, dump_vk, from_json_file, serialize_instance
 use crate::io::serialize_fr_vec;
 use anyhow::Result;
 use serde_derive::{Deserialize, Serialize};
+use snark_verifier_sdk::encode_calldata;
 
 const ACC_LEN: usize = 12;
 const PI_LEN: usize = 32;
@@ -9,7 +10,7 @@ const PI_LEN: usize = 32;
 const ACC_BYTES: usize = ACC_LEN * 32;
 const PI_BYTES: usize = PI_LEN * 32;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BatchProof {
     #[serde(flatten)]
     raw: Proof,
@@ -77,6 +78,17 @@ impl BatchProof {
             instances,
             vk,
         }
+    }
+
+    // Only used for debugging.
+    pub fn assert_calldata(&self) {
+        let proof = self.clone().proof_to_verify();
+        let expected_calldata = encode_calldata(&proof.instances(), &proof.proof);
+
+        let mut result_calldata = self.raw.instances.clone();
+        result_calldata.extend(self.raw.proof.clone());
+
+        assert_eq!(result_calldata, expected_calldata);
     }
 }
 

--- a/prover/src/proof/batch.rs
+++ b/prover/src/proof/batch.rs
@@ -90,18 +90,6 @@ impl BatchProof {
         result_calldata.extend(self.raw.instances.clone());
         result_calldata.extend(proof);
 
-        log::error!("expected_calldata - BEGIN");
-        for c in expected_calldata.chunks(32) {
-            log::error!("{c:?}");
-        }
-        log::error!("expected_calldata - END");
-
-        log::error!("result_calldata - BEGIN");
-        for c in result_calldata.chunks(32) {
-            log::error!("{c:?}");
-        }
-        log::error!("result_calldata - END");
-
         assert_eq!(result_calldata, expected_calldata);
     }
 }

--- a/prover/tests/aggregation_tests.rs
+++ b/prover/tests/aggregation_tests.rs
@@ -75,6 +75,8 @@ fn gen_and_verify_evm_proof(
     log::info!("Constructed aggregator verifier");
 
     let batch_proof = BatchProof::from(evm_proof.proof.clone());
+    batch_proof.assert_calldata();
+
     batch_proof.dump(output_dir, "agg").unwrap();
 
     let success = verifier.verify_agg_evm_proof(batch_proof);


### PR DESCRIPTION
### Summary

- Fix `serialize_instance` as [encode_calldata in snark-verifier](https://github.com/scroll-tech/snark-verifier/blob/develop/snark-verifier/src/loader/evm/util.rs#L89).

- Add a function `assert_calldata` to `BatchProof`. It combines raw proof and instances to calldata, then assert equal with the result of `encode_calldata`.