### PR TITLE
fix: add ENVs for layer config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "ark-std",
  "env_logger 0.10.0",
@@ -418,7 +418,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "eth-types",
  "ethers-core 0.17.0",
@@ -1121,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "ethers-core 0.17.0",
  "ethers-signers",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "env_logger 0.9.3",
  "gobuild 0.1.0-alpha.2 (git+https://github.com/scroll-tech/gobuild.git)",
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "env_logger 0.9.3",
  "eth-types",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "eth-types",
  "ethers-core 0.17.0",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "bus-mapping",
  "eth-types",
@@ -4711,7 +4711,7 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#c4db809fd72553ec9efad82813dbd3a63434ab02"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=develop#225db80d26b6a2ed4aa5ad2462c887a58acdfd00"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/prover/src/aggregator/verifier.rs
+++ b/prover/src/aggregator/verifier.rs
@@ -1,4 +1,10 @@
-use crate::{common, config::LAYER4_DEGREE, io::read_all, utils::read_env_var, BatchProof};
+use crate::{
+    common,
+    config::{LAYER4_CONFIG_PATH, LAYER4_DEGREE},
+    io::read_all,
+    utils::read_env_var,
+    BatchProof,
+};
 use aggregator::CompressionCircuit;
 use halo2_proofs::{
     halo2curves::bn256::{Bn256, G1Affine},
@@ -45,7 +51,7 @@ impl Verifier {
         let raw_vk = read_all(&vk_path);
         let deployment_code = read_all(&deployment_code_path);
 
-        env::set_var("COMPRESSION_CONFIG", "./configs/layer4.config");
+        env::set_var("COMPRESSION_CONFIG", &*LAYER4_CONFIG_PATH);
         let inner = common::Verifier::from_params_dir(params_dir, *LAYER4_DEGREE, &raw_vk);
 
         Self {

--- a/prover/src/common/prover/aggregation.rs
+++ b/prover/src/common/prover/aggregation.rs
@@ -1,5 +1,6 @@
 use super::Prover;
 use crate::{
+    config::layer_config_path,
     io::{load_snark, write_snark},
     utils::gen_rng,
 };
@@ -18,7 +19,7 @@ impl Prover {
         chunk_hashes: &[ChunkHash],
         previous_snarks: &[Snark],
     ) -> Result<Snark> {
-        env::set_var("AGGREGATION_CONFIG", format!("./configs/{id}.config"));
+        env::set_var("AGGREGATION_CONFIG", layer_config_path(id));
 
         let batch_hash = BatchHash::construct(chunk_hashes);
 

--- a/prover/src/common/prover/compression.rs
+++ b/prover/src/common/prover/compression.rs
@@ -1,5 +1,6 @@
 use super::Prover;
 use crate::{
+    config::layer_config_path,
     io::{load_snark, write_snark},
     utils::gen_rng,
 };
@@ -18,7 +19,7 @@ impl Prover {
         mut rng: impl Rng + Send,
         prev_snark: Snark,
     ) -> Result<Snark> {
-        env::set_var("COMPRESSION_CONFIG", format!("./configs/{id}.config"));
+        env::set_var("COMPRESSION_CONFIG", layer_config_path(id));
 
         let circuit =
             CompressionCircuit::new(self.params(degree), prev_snark, has_accumulator, &mut rng)

--- a/prover/src/common/prover/evm.rs
+++ b/prover/src/common/prover/evm.rs
@@ -1,11 +1,11 @@
 use super::Prover;
-use crate::{utils::gen_rng, EvmProof};
+use crate::{config::layer_config_path, utils::gen_rng, EvmProof};
 use aggregator::CompressionCircuit;
 use anyhow::{anyhow, Result};
 use halo2_proofs::halo2curves::bn256::Fr;
 use rand::Rng;
 use snark_verifier_sdk::{gen_evm_proof_shplonk, CircuitExt, Snark};
-use std::env::set_var;
+use std::env;
 
 impl Prover {
     pub fn load_or_gen_comp_evm_proof(
@@ -21,7 +21,7 @@ impl Prover {
         match output_dir.and_then(|output_dir| EvmProof::from_json_file(output_dir, &name).ok()) {
             Some(proof) => Ok(proof),
             None => {
-                set_var("COMPRESSION_CONFIG", format!("./configs/{id}.config"));
+                env::set_var("COMPRESSION_CONFIG", layer_config_path(id));
 
                 let mut rng = gen_rng();
                 let circuit = CompressionCircuit::new(

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -1,12 +1,22 @@
 use crate::utils::read_env_var;
+use aggregator::ConfigParams;
 use once_cell::sync::Lazy;
-use std::collections::HashSet;
+use std::{collections::HashSet, fs::File, path::Path};
 
-pub static INNER_DEGREE: Lazy<u32> = Lazy::new(|| read_env_var("INNER_DEGREE", 20));
-pub static LAYER1_DEGREE: Lazy<u32> = Lazy::new(|| read_env_var("LAYER1_DEGREE", 24));
-pub static LAYER2_DEGREE: Lazy<u32> = Lazy::new(|| read_env_var("LAYER2_DEGREE", 24));
-pub static LAYER3_DEGREE: Lazy<u32> = Lazy::new(|| read_env_var("LAYER3_DEGREE", 19));
-pub static LAYER4_DEGREE: Lazy<u32> = Lazy::new(|| read_env_var("LAYER4_DEGREE", 25));
+pub static INNER_DEGREE: Lazy<u32> = Lazy::new(|| read_env_var("SCROLL_PROVER_INNER_DEGREE", 20));
+
+pub static ASSETS_DIR: Lazy<String> =
+    Lazy::new(|| read_env_var("SCROLL_PROVER_ASSETS_DIR", "configs".to_string()));
+
+pub static LAYER1_CONFIG_PATH: Lazy<String> = Lazy::new(|| asset_file_path("layer1.config"));
+pub static LAYER2_CONFIG_PATH: Lazy<String> = Lazy::new(|| asset_file_path("layer2.config"));
+pub static LAYER3_CONFIG_PATH: Lazy<String> = Lazy::new(|| asset_file_path("layer3.config"));
+pub static LAYER4_CONFIG_PATH: Lazy<String> = Lazy::new(|| asset_file_path("layer4.config"));
+
+pub static LAYER1_DEGREE: Lazy<u32> = Lazy::new(|| layer_degree(&LAYER1_CONFIG_PATH));
+pub static LAYER2_DEGREE: Lazy<u32> = Lazy::new(|| layer_degree(&LAYER2_CONFIG_PATH));
+pub static LAYER3_DEGREE: Lazy<u32> = Lazy::new(|| layer_degree(&LAYER3_CONFIG_PATH));
+pub static LAYER4_DEGREE: Lazy<u32> = Lazy::new(|| layer_degree(&LAYER4_CONFIG_PATH));
 
 pub static ZKEVM_DEGREES: Lazy<Vec<u32>> = Lazy::new(|| {
     Vec::from_iter(HashSet::from([
@@ -18,3 +28,29 @@ pub static ZKEVM_DEGREES: Lazy<Vec<u32>> = Lazy::new(|| {
 
 pub static AGG_DEGREES: Lazy<Vec<u32>> =
     Lazy::new(|| Vec::from_iter(HashSet::from([*LAYER3_DEGREE, *LAYER4_DEGREE])));
+
+pub fn layer_config_path(id: &str) -> &str {
+    match id {
+        "layer1" => &LAYER1_CONFIG_PATH,
+        "layer2" => &LAYER2_CONFIG_PATH,
+        "layer3" => &LAYER3_CONFIG_PATH,
+        "layer4" => &LAYER4_CONFIG_PATH,
+        _ => panic!("Wrong id-{id} to get layer config path"),
+    }
+}
+
+fn asset_file_path(filename: &str) -> String {
+    Path::new(&*ASSETS_DIR)
+        .join(filename)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn layer_degree(config_file: &str) -> u32 {
+    let f = File::open(config_file).unwrap_or_else(|_| panic!("Failed to open {config_file}"));
+
+    let params: ConfigParams =
+        serde_json::from_reader(f).unwrap_or_else(|_| panic!("Failed to parse {config_file}"));
+
+    params.degree
+}

--- a/prover/src/zkevm/verifier.rs
+++ b/prover/src/zkevm/verifier.rs
@@ -1,4 +1,10 @@
-use crate::{common, config::LAYER2_DEGREE, io::read_all, utils::read_env_var, ChunkProof};
+use crate::{
+    common,
+    config::{LAYER2_CONFIG_PATH, LAYER2_DEGREE},
+    io::read_all,
+    utils::read_env_var,
+    ChunkProof,
+};
 use aggregator::CompressionCircuit;
 use halo2_proofs::{
     halo2curves::bn256::{Bn256, G1Affine},
@@ -36,7 +42,7 @@ impl Verifier {
 
         let raw_vk = read_all(&vk_path);
 
-        env::set_var("COMPRESSION_CONFIG", "./configs/layer2.config");
+        env::set_var("COMPRESSION_CONFIG", &*LAYER2_CONFIG_PATH);
         common::Verifier::from_params_dir(params_dir, *LAYER2_DEGREE, &raw_vk).into()
     }
 

--- a/prover/tests/aggregation_tests.rs
+++ b/prover/tests/aggregation_tests.rs
@@ -2,7 +2,7 @@ use aggregator::CompressionCircuit;
 use prover::{
     aggregator::{Prover, Verifier},
     common,
-    config::LAYER4_DEGREE,
+    config::{LAYER4_CONFIG_PATH, LAYER4_DEGREE},
     test_util::{load_block_traces_for_test, PARAMS_DIR},
     utils::{chunk_trace_to_witness_block, init_env_and_log},
     zkevm, BatchProof, ChunkHash, ChunkProof, EvmProof, Proof,
@@ -63,7 +63,7 @@ fn gen_and_verify_evm_proof(
         .unwrap();
     log::info!("Got compression-EVM-proof (layer-4)");
 
-    env::set_var("COMPRESSION_CONFIG", "./configs/layer4.config");
+    env::set_var("COMPRESSION_CONFIG", &*LAYER4_CONFIG_PATH);
     let vk = evm_proof.proof.vk::<CompressionCircuit>();
 
     let params = prover.inner.params(*LAYER4_DEGREE).clone();

--- a/prover/tests/chunk_tests.rs
+++ b/prover/tests/chunk_tests.rs
@@ -1,6 +1,6 @@
 use aggregator::CompressionCircuit;
 use prover::{
-    config::LAYER2_DEGREE,
+    config::{LAYER2_CONFIG_PATH, LAYER2_DEGREE},
     test_util::{load_block_traces_for_test, PARAMS_DIR},
     utils::{chunk_trace_to_witness_block, init_env_and_log},
     zkevm::{Prover, Verifier},
@@ -52,7 +52,7 @@ fn gen_and_verify_evm_proof(
         .unwrap();
     log::info!("Got compression-EVM-proof (layer-2)");
 
-    env::set_var("COMPRESSION_CONFIG", "./configs/layer2.config");
+    env::set_var("COMPRESSION_CONFIG", &*LAYER2_CONFIG_PATH);
     let vk = evm_proof.proof.vk::<CompressionCircuit>();
 
     let params = prover.inner.params(*LAYER2_DEGREE).clone();


### PR DESCRIPTION
### Summary

- ENV `SCROLL_PROVER_INNER_DEGREE` is used to set super-circuit degree (default as `20`).
- ENV `SCROLL_PROVER_ASSETS_DIR` is used for layer config files (default as `./configs`).
- Delete ENV `LAYER1_DEGREE` .. `LAYER4_DEGREE`, they are parsed from config file.
- Upgrade zkevm-circuits develop branch.

### Test
- [x] Testing this branch on server (delete original dir `prover/configs`, and  export`SCROLL_PROVER_ASSET_DIR = "/home/ubuntu/xxx/configs"`).