### PR TITLE
fix: add `git_version` to both chunk and batch proofs

### DIFF
--- a/prover/src/proof.rs
+++ b/prover/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     io::{deserialize_fr, deserialize_vk, serialize_fr, serialize_vk, write_file},
-    utils::GIT_VERSION,
+    utils::short_git_version,
 };
 use anyhow::{bail, Result};
 use halo2_proofs::{
@@ -45,7 +45,7 @@ impl Proof {
     pub fn new(proof: Vec<u8>, instances: &[Vec<Fr>], pk: Option<&ProvingKey<G1Affine>>) -> Self {
         let instances = serialize_instances(instances);
         let vk = pk.map_or_else(Vec::new, |pk| serialize_vk(pk.get_vk()));
-        let git_version = Some(GIT_VERSION.to_string());
+        let git_version = Some(short_git_version());
 
         Self {
             proof,
@@ -62,7 +62,7 @@ impl Proof {
     pub fn from_snark(snark: Snark, vk: Vec<u8>) -> Self {
         let proof = snark.proof;
         let instances = serialize_instances(&snark.instances);
-        let git_version = Some(GIT_VERSION.to_string());
+        let git_version = Some(short_git_version());
 
         Proof {
             proof,

--- a/prover/src/proof.rs
+++ b/prover/src/proof.rs
@@ -1,4 +1,7 @@
-use crate::io::{deserialize_fr, deserialize_vk, serialize_fr, serialize_vk, write_file};
+use crate::{
+    io::{deserialize_fr, deserialize_vk, serialize_fr, serialize_vk, write_file},
+    utils::GIT_VERSION,
+};
 use anyhow::{bail, Result};
 use halo2_proofs::{
     halo2curves::bn256::{Fr, G1Affine},
@@ -35,17 +38,20 @@ pub struct Proof {
     instances: Vec<u8>,
     #[serde(with = "base64")]
     vk: Vec<u8>,
+    pub git_version: Option<String>,
 }
 
 impl Proof {
     pub fn new(proof: Vec<u8>, instances: &[Vec<Fr>], pk: Option<&ProvingKey<G1Affine>>) -> Self {
         let instances = serialize_instances(instances);
         let vk = pk.map_or_else(Vec::new, |pk| serialize_vk(pk.get_vk()));
+        let git_version = Some(GIT_VERSION.to_string());
 
         Self {
             proof,
             instances,
             vk,
+            git_version,
         }
     }
 
@@ -54,12 +60,15 @@ impl Proof {
     }
 
     pub fn from_snark(snark: Snark, vk: Vec<u8>) -> Self {
+        let proof = snark.proof;
         let instances = serialize_instances(&snark.instances);
+        let git_version = Some(GIT_VERSION.to_string());
 
         Proof {
-            proof: snark.proof,
-            vk,
+            proof,
             instances,
+            vk,
+            git_version,
         }
     }
 

--- a/prover/src/proof/batch.rs
+++ b/prover/src/proof/batch.rs
@@ -1,4 +1,5 @@
 use super::{dump_as_json, dump_data, dump_vk, from_json_file, serialize_instance, Proof};
+use crate::utils::GIT_VERSION;
 use anyhow::Result;
 use serde_derive::{Deserialize, Serialize};
 use snark_verifier_sdk::encode_calldata;
@@ -32,11 +33,14 @@ impl From<Proof> for BatchProof {
         // raw_instances = pi_data
         let instances = serialize_instance(&instances[0][ACC_LEN..]);
 
+        let git_version = Some(GIT_VERSION.to_string());
+
         Self {
             raw: Proof {
                 proof,
                 instances,
                 vk,
+                git_version,
             },
         }
     }
@@ -79,11 +83,13 @@ impl BatchProof {
         instances.extend(self.raw.instances);
 
         let vk = self.raw.vk;
+        let git_version = Some(GIT_VERSION.to_string());
 
         Proof {
             proof,
             instances,
             vk,
+            git_version,
         }
     }
 

--- a/prover/src/proof/batch.rs
+++ b/prover/src/proof/batch.rs
@@ -40,7 +40,7 @@ impl From<Proof> for BatchProof {
                 proof,
                 instances,
                 vk,
-                git_version,
+                proof.git_version,
             },
         }
     }

--- a/prover/src/proof/batch.rs
+++ b/prover/src/proof/batch.rs
@@ -1,5 +1,5 @@
 use super::{dump_as_json, dump_data, dump_vk, from_json_file, serialize_instance, Proof};
-use crate::utils::GIT_VERSION;
+use crate::utils::short_git_version;
 use anyhow::Result;
 use serde_derive::{Deserialize, Serialize};
 use snark_verifier_sdk::encode_calldata;
@@ -23,6 +23,7 @@ impl From<Proof> for BatchProof {
         assert_eq!(instances[0].len(), ACC_LEN + PI_LEN);
 
         let vk = proof.vk;
+        let git_version = proof.git_version;
 
         // raw_proof = acc + proof
         let proof = serialize_instance(&instances[0][..ACC_LEN])
@@ -33,14 +34,12 @@ impl From<Proof> for BatchProof {
         // raw_instances = pi_data
         let instances = serialize_instance(&instances[0][ACC_LEN..]);
 
-        let git_version = Some(GIT_VERSION.to_string());
-
         Self {
             raw: Proof {
                 proof,
                 instances,
                 vk,
-                proof.git_version,
+                git_version,
             },
         }
     }
@@ -83,7 +82,7 @@ impl BatchProof {
         instances.extend(self.raw.instances);
 
         let vk = self.raw.vk;
-        let git_version = Some(GIT_VERSION.to_string());
+        let git_version = Some(short_git_version());
 
         Proof {
             proof,

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -195,7 +195,7 @@ pub fn gen_rng() -> impl Rng + Send {
 
 pub fn short_git_version() -> String {
     let output = Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"])
         .output()
         .expect("Failed to execute git command");
 

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -160,6 +160,7 @@ pub fn init_env_and_log(id: &str) -> String {
         log4rs::init_config(config).unwrap();
 
         log::info!("git version {}", GIT_VERSION);
+        log::info!("short git version {}", short_git_version());
     });
 
     output_dir
@@ -193,7 +194,7 @@ pub fn gen_rng() -> impl Rng + Send {
 }
 
 pub fn short_git_version() -> String {
-    GIT_VERSION.split("-").last().unwrap()[1..8].to_string()
+    GIT_VERSION.split('-').last().unwrap()[1..8].to_string()
 }
 
 pub fn tick(desc: &str) {

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -29,6 +29,7 @@ use zkevm_circuits::evm_circuit::witness::Block;
 
 pub const DEFAULT_SERDE_FORMAT: SerdeFormat = SerdeFormat::RawBytesUnchecked;
 pub const GIT_VERSION: &str = git_version!();
+pub const GIT_VERSION_SHORT_LEN: usize = 7;
 pub static LOGGER: Once = Once::new();
 
 /// Load setup params from a file.
@@ -190,6 +191,10 @@ pub fn param_path_for_degree(params_dir: &str, degree: u32) -> String {
 pub fn gen_rng() -> impl Rng + Send {
     let seed = [0u8; 16];
     XorShiftRng::from_seed(seed)
+}
+
+pub fn short_git_version() -> String {
+    GIT_VERSION[..GIT_VERSION_SHORT_LEN].to_string()
 }
 
 pub fn tick(desc: &str) {

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -21,7 +21,6 @@ use std::{
     fs::{self, metadata, File},
     io::{BufReader, Read},
     path::{Path, PathBuf},
-    process::Command,
     str::FromStr,
     sync::Once,
 };
@@ -194,12 +193,7 @@ pub fn gen_rng() -> impl Rng + Send {
 }
 
 pub fn short_git_version() -> String {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .expect("Failed to execute git command");
-
-    String::from_utf8_lossy(&output.stdout).trim().to_string()
+    GIT_VERSION.split("-").last().unwrap()[1..8].to_string()
 }
 
 pub fn tick(desc: &str) {

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -21,6 +21,7 @@ use std::{
     fs::{self, metadata, File},
     io::{BufReader, Read},
     path::{Path, PathBuf},
+    process::Command,
     str::FromStr,
     sync::Once,
 };
@@ -29,7 +30,6 @@ use zkevm_circuits::evm_circuit::witness::Block;
 
 pub const DEFAULT_SERDE_FORMAT: SerdeFormat = SerdeFormat::RawBytesUnchecked;
 pub const GIT_VERSION: &str = git_version!();
-pub const GIT_VERSION_SHORT_LEN: usize = 7;
 pub static LOGGER: Once = Once::new();
 
 /// Load setup params from a file.
@@ -194,7 +194,12 @@ pub fn gen_rng() -> impl Rng + Send {
 }
 
 pub fn short_git_version() -> String {
-    GIT_VERSION[..GIT_VERSION_SHORT_LEN].to_string()
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("Failed to execute git command");
+
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
 pub fn tick(desc: &str) {

--- a/prover/tests/integration.rs
+++ b/prover/tests/integration.rs
@@ -10,7 +10,6 @@ use prover::{
     test_util::{load_block_traces_for_test, parse_trace_path_from_mode, PARAMS_DIR},
     utils::{
         get_block_trace_from_file, init_env_and_log, load_params, short_git_version,
-        GIT_VERSION_SHORT_LEN,
     },
     zkevm::{
         circuit::{block_traces_to_padding_witness_block, SuperCircuit, TargetCircuit},
@@ -24,9 +23,9 @@ fn test_short_git_version() {
     init_env_and_log("integration");
 
     let git_version = short_git_version();
-    log::info!("git_version = {git_version}");
+    log::info!("short_git_version = {git_version}");
 
-    assert_eq!(git_version.len(), GIT_VERSION_SHORT_LEN);
+    assert_eq!(git_version.len(), 7);
 }
 
 #[ignore]

--- a/prover/tests/integration.rs
+++ b/prover/tests/integration.rs
@@ -8,9 +8,7 @@ use prover::{
     inner::{Prover, Verifier},
     io::serialize_vk,
     test_util::{load_block_traces_for_test, parse_trace_path_from_mode, PARAMS_DIR},
-    utils::{
-        get_block_trace_from_file, init_env_and_log, load_params, short_git_version,
-    },
+    utils::{get_block_trace_from_file, init_env_and_log, load_params, short_git_version},
     zkevm::{
         circuit::{block_traces_to_padding_witness_block, SuperCircuit, TargetCircuit},
         CircuitCapacityChecker,

--- a/prover/tests/integration.rs
+++ b/prover/tests/integration.rs
@@ -8,13 +8,26 @@ use prover::{
     inner::{Prover, Verifier},
     io::serialize_vk,
     test_util::{load_block_traces_for_test, parse_trace_path_from_mode, PARAMS_DIR},
-    utils::{get_block_trace_from_file, init_env_and_log, load_params},
+    utils::{
+        get_block_trace_from_file, init_env_and_log, load_params, short_git_version,
+        GIT_VERSION_SHORT_LEN,
+    },
     zkevm::{
         circuit::{block_traces_to_padding_witness_block, SuperCircuit, TargetCircuit},
         CircuitCapacityChecker,
     },
 };
 use zkevm_circuits::util::SubCircuit;
+
+#[test]
+fn test_short_git_version() {
+    init_env_and_log("integration");
+
+    let git_version = short_git_version();
+    log::info!("git_version = {git_version}");
+
+    assert_eq!(git_version.len(), GIT_VERSION_SHORT_LEN);
+}
 
 #[ignore]
 #[test]


### PR DESCRIPTION
### Summary

- Add a function `short_git_version` to get short commit version.
- Add this git version to both chunk and batch proofs.