### PR TITLE
feat: dump chunk-protocol, and check it when gen batch proof

### DIFF
--- a/prover/src/aggregator/prover.rs
+++ b/prover/src/aggregator/prover.rs
@@ -37,8 +37,8 @@ impl Prover {
         }
     }
 
-    // Return true if chunk protocol is same with the one in prover, false otherwise.
-    pub fn check_chunk_protocol(&self, chunk_proofs: &[ChunkProof]) -> bool {
+    // Return true if chunk proofs are valid (same protocol), false otherwise.
+    pub fn check_chunk_proofs(&self, chunk_proofs: &[ChunkProof]) -> bool {
         chunk_proofs
             .iter()
             .all(|proof| proof.protocol == self.chunk_protocol)
@@ -100,7 +100,7 @@ impl Prover {
         let (mut chunk_hashes, chunk_proofs): (Vec<_>, Vec<_>) =
             chunk_hashes_proofs.into_iter().unzip();
 
-        if !self.check_chunk_protocol(&chunk_proofs) {
+        if !self.check_chunk_proofs(&chunk_proofs) {
             bail!("non-match-chunk-protocol: {name}");
         }
 

--- a/prover/src/proof/chunk.rs
+++ b/prover/src/proof/chunk.rs
@@ -1,4 +1,4 @@
-use super::{dump_as_json, dump_vk, from_json_file, Proof};
+use super::{dump_as_json, dump_data, dump_vk, from_json_file, Proof};
 use crate::ChunkHash;
 use anyhow::Result;
 use halo2_proofs::{halo2curves::bn256::G1Affine, plonk::ProvingKey};
@@ -45,7 +45,10 @@ impl ChunkProof {
     pub fn dump(&self, dir: &str, name: &str) -> Result<()> {
         let filename = dump_filename(name);
 
+        // Dump vk and protocol.
         dump_vk(dir, &filename, &self.proof.vk);
+        dump_data(dir, &format!("proto_{filename}.protocol"), &self.protocol);
+
         dump_as_json(dir, &filename, &self)
     }
 

--- a/prover/src/proof/chunk.rs
+++ b/prover/src/proof/chunk.rs
@@ -47,7 +47,7 @@ impl ChunkProof {
 
         // Dump vk and protocol.
         dump_vk(dir, &filename, &self.proof.vk);
-        dump_data(dir, &format!("proto_{filename}.protocol"), &self.protocol);
+        dump_data(dir, &format!("chunk_{filename}.protocol"), &self.protocol);
 
         dump_as_json(dir, &filename, &self)
     }

--- a/prover/tests/aggregation_tests.rs
+++ b/prover/tests/aggregation_tests.rs
@@ -16,9 +16,6 @@ fn test_agg_prove_verify() {
     let output_dir = init_env_and_log("agg_tests");
     log::info!("Initialized ENV and created output-dir {output_dir}");
 
-    let mut agg_prover = Prover::from_params_dir(PARAMS_DIR);
-    log::info!("Constructed aggregation prover");
-
     let trace_paths = vec![
         "./tests/traces/erc20/1_transfer.json".to_string(),
         "./tests/traces/erc20/10_transfer.json".to_string(),
@@ -26,6 +23,10 @@ fn test_agg_prove_verify() {
 
     let chunk_hashes_proofs = gen_chunk_hashes_and_proofs(&output_dir, &trace_paths);
     log::info!("Generated chunk hashes and proofs");
+
+    env::set_var("CHUNK_PROTOCOL_FILENAME", "chunk_chunk_0.protocol");
+    let mut agg_prover = Prover::from_dirs(PARAMS_DIR, &output_dir);
+    log::info!("Constructed aggregation prover");
 
     // Load or generate aggregation snark (layer-3).
     let layer3_snark = agg_prover
@@ -130,12 +131,13 @@ fn gen_chunk_hashes_and_proofs(
 
     chunk_traces
         .into_iter()
-        .map(|chunk_trace| {
+        .enumerate()
+        .map(|(i, chunk_trace)| {
             let witness_block = chunk_trace_to_witness_block(chunk_trace.clone()).unwrap();
             let chunk_hash = ChunkHash::from_witness_block(&witness_block, false);
 
             let proof = zkevm_prover
-                .gen_chunk_proof(chunk_trace, None, Some(output_dir))
+                .gen_chunk_proof(chunk_trace, Some(&i.to_string()), Some(output_dir))
                 .unwrap();
 
             (chunk_hash, proof)


### PR DESCRIPTION
- [ ] Suppose to test again based on new release.

### Summary

Related scroll PR https://github.com/scroll-tech/scroll/pull/807

- Add chunk-protocol when init aggregator prover, and check it with protocols in chunk-proofs when gen batch-proof.
- Dump chunk-protocol when dump chunk-proof (used to save chunk-protocol as asset file).
- Suppose if could also call `chunk_chunk_proofs` in go-prover of scroll, it could generate the clear error (to coordinator).

### Test 

- Aggregation-tests could pass.