### PR TITLE
normalize row usage: 1M means 100%

### DIFF
--- a/prover/src/zkevm/capacity_checker.rs
+++ b/prover/src/zkevm/capacity_checker.rs
@@ -68,7 +68,7 @@ impl RowUsage {
             7 * MAX_EXP_STEPS, // exp
             MAX_KECCAK_ROWS,
             MAX_RWS,
-            MAX_MPT_ROWS,  /* poseidon */
+            MAX_MPT_ROWS,  // poseidon
             (1 << 20) - 256, // sig
             (1 << 20) - 256, // FIXME: pairing may be limit to 1, fix later
             MAX_MPT_ROWS,

--- a/prover/src/zkevm/capacity_checker.rs
+++ b/prover/src/zkevm/capacity_checker.rs
@@ -69,8 +69,8 @@ impl RowUsage {
             MAX_KECCAK_ROWS,
             MAX_RWS,
             MAX_MPT_ROWS,  /* poseidon */
-            1 << 20 - 256, // sig
-            1 << 20 - 256, // FIXME: pairing may be limit to 1, fix later
+            (1 << 20) - 256, // sig
+            (1 << 20) - 256, // FIXME: pairing may be limit to 1, fix later
             MAX_MPT_ROWS,
         ]
         .map(|x| (x as f32 * 0.95) as usize);

--- a/prover/src/zkevm/capacity_checker.rs
+++ b/prover/src/zkevm/capacity_checker.rs
@@ -114,7 +114,6 @@ impl RowUsage {
             .max()
             .unwrap();
         self.is_ok = self.row_number < 1_000_000;
-        // self.is_ok = self.row_number < (1 << *INNER_DEGREE) - 256;
     }
 }
 

--- a/prover/src/zkevm/circuit.rs
+++ b/prover/src/zkevm/circuit.rs
@@ -20,17 +20,17 @@ pub use self::builder::{
 // TODO: more smart row capacity checking rather than max_of(row_usage_details) > 1<<20 - 256
 // Need to compare with real row nums like MAX_MPT_ROWS/MAX_KECCAK_ROWS etc.
 ////// params for degree = 20 ////////////
-const MAX_TXS: usize = 100;
-const MAX_INNER_BLOCKS: usize = 100;
-const MAX_EXP_STEPS: usize = 10_000;
-const MAX_CALLDATA: usize = 400_000;
-const MAX_BYTECODE: usize = 400_000;
-const MAX_MPT_ROWS: usize = 400_000;
-const MAX_KECCAK_ROWS: usize = 524_000;
-const MAX_RWS: usize = 1_000_000;
-const MAX_PRECOMPILE_EC_ADD: usize = 50;
-const MAX_PRECOMPILE_EC_MUL: usize = 50;
-const MAX_PRECOMPILE_EC_PAIRING: usize = 2;
+pub const MAX_TXS: usize = 100;
+pub const MAX_INNER_BLOCKS: usize = 100;
+pub const MAX_EXP_STEPS: usize = 10_000;
+pub const MAX_CALLDATA: usize = 400_000;
+pub const MAX_BYTECODE: usize = 400_000;
+pub const MAX_MPT_ROWS: usize = 400_000;
+pub const MAX_KECCAK_ROWS: usize = 524_000;
+pub const MAX_RWS: usize = 1_000_000;
+pub const MAX_PRECOMPILE_EC_ADD: usize = 50;
+pub const MAX_PRECOMPILE_EC_MUL: usize = 50;
+pub const MAX_PRECOMPILE_EC_PAIRING: usize = 2;
 
 static CHAIN_ID: Lazy<u64> = Lazy::new(|| read_env_var("CHAIN_ID", 53077));
 static AUTO_TRUNCATE: Lazy<bool> = Lazy::new(|| read_env_var("AUTO_TRUNCATE", false));


### PR DESCRIPTION
the core idea here is we normalize real sub circuit row usages against 1M.

The row consumption is no longer real row num.

To avoid too many changes in chunk proposer.