### PR TITLE
Small refactor on `test_util` (will use for mass-testing)

### DIFF
--- a/prover/src/common/verifier/evm.rs
+++ b/prover/src/common/verifier/evm.rs
@@ -7,21 +7,26 @@ use std::{path::PathBuf, str::FromStr};
 
 impl<C: CircuitExt<Fr>> Verifier<C> {
     // Should panic if failed to verify.
-    pub fn evm_verify(&self, evm_proof: &EvmProof, output_dir: &str) {
-        let mut yul_file_path = PathBuf::from_str(output_dir).unwrap();
-        yul_file_path.push("evm_verifier.yul");
+    pub fn evm_verify(&self, evm_proof: &EvmProof, output_dir: Option<&str>) {
+        let yul_file_path = output_dir.map(|dir| {
+            let mut path = PathBuf::from_str(dir).unwrap();
+            path.push("evm_verifier.yul");
+            path
+        });
 
         // Generate deployment code and dump YUL file.
         let deployment_code = gen_evm_verifier::<C, Kzg<Bn256, Bdfg21>>(
             &self.params,
             &self.vk,
             evm_proof.num_instance.clone(),
-            Some(yul_file_path.as_path()),
+            yul_file_path.as_deref(),
         );
 
-        // Dump bytecode.
-        let mut output_dir = PathBuf::from_str(output_dir).unwrap();
-        write_file(&mut output_dir, "evm_verifier.bin", &deployment_code);
+        if let Some(dir) = output_dir {
+            // Dump bytecode.
+            let mut dir = PathBuf::from_str(dir).unwrap();
+            write_file(&mut dir, "evm_verifier.bin", &deployment_code);
+        }
 
         let success = evm_proof.proof.evm_verify(deployment_code);
         assert!(success);

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -29,6 +29,7 @@ pub static ZKEVM_DEGREES: Lazy<Vec<u32>> = Lazy::new(|| {
 pub static AGG_DEGREES: Lazy<Vec<u32>> =
     Lazy::new(|| Vec::from_iter(HashSet::from([*LAYER3_DEGREE, *LAYER4_DEGREE])));
 
+#[derive(Clone, Copy, Debug)]
 pub enum LayerId {
     /// Compression wide layer
     Layer1,

--- a/prover/src/test_util.rs
+++ b/prover/src/test_util.rs
@@ -5,7 +5,9 @@ use types::eth::BlockTrace;
 pub mod mock_plonk;
 mod proof;
 
-pub use proof::{gen_and_verify_batch_proofs, gen_and_verify_chunk_proofs};
+pub use proof::{
+    gen_and_verify_batch_proofs, gen_and_verify_chunk_proofs, gen_and_verify_normal_and_evm_proofs,
+};
 
 pub const PARAMS_DIR: &str = "./test_params";
 


### PR DESCRIPTION
### Summary

Make `test_util` functions could be passed into `output_dir` as None (not-saved).