### PR TITLE
Feat: add capacity for RLP circuit

### DIFF
--- a/prover/src/zkevm/circuit/builder.rs
+++ b/prover/src/zkevm/circuit/builder.rs
@@ -25,7 +25,8 @@ pub type WitnessBlock = Block<Fr>;
 pub const MAX_TXS: usize = 100;
 pub const MAX_INNER_BLOCKS: usize = 100;
 pub const MAX_EXP_STEPS: usize = 10_000;
-pub const MAX_CALLDATA: usize = 600_000;
+pub const MAX_CALLDATA: usize = 350_000;
+pub const MAX_RLP_ROWS: usize = 800_000;
 pub const MAX_BYTECODE: usize = 600_000;
 pub const MAX_MPT_ROWS: usize = 1_000_000;
 pub const MAX_KECCAK_ROWS: usize = 1_000_000;
@@ -51,7 +52,7 @@ pub fn get_super_circuit_params() -> CircuitsParams {
         max_vertical_circuit_rows: MAX_VERTICLE_ROWS,
         max_exp_steps: MAX_EXP_STEPS,
         max_mpt_rows: MAX_MPT_ROWS,
-        max_rlp_rows: MAX_CALLDATA,
+        max_rlp_rows: MAX_RLP_ROWS,
         max_ec_ops: PrecompileEcParams {
             ec_add: MAX_PRECOMPILE_EC_ADD,
             ec_mul: MAX_PRECOMPILE_EC_MUL,


### PR DESCRIPTION
 We want to have `2*MAX_CALLDATA < MAX_RLP_ROWS` because each call data byte in a L2 tx takes two rows in the RLP circuit.

- add capacity for RLP circuit: 800k
- downsize the capacity of Tx circuit: 600k -> 350k since a batch can only have less than 200KB in the rollup contract.