### PR TITLE
fix: add test function `gen_and_verify_normal_proof`

### DIFF
--- a/prover/src/common.rs
+++ b/prover/src/common.rs
@@ -2,4 +2,4 @@ mod prover;
 mod verifier;
 
 pub use self::{prover::Prover, verifier::Verifier};
-pub use aggregator::ChunkHash;
+pub use aggregator::{ChunkHash, CompressionCircuit};

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -11,7 +11,7 @@ pub mod types;
 pub mod utils;
 pub mod zkevm;
 
-pub use common::ChunkHash;
+pub use common::{ChunkHash, CompressionCircuit};
 pub use evm_verifier::EvmVerifier;
 pub use proof::{BatchProof, ChunkProof, EvmProof, Proof};
 pub use snark_verifier_sdk::Snark;

--- a/prover/src/test_util.rs
+++ b/prover/src/test_util.rs
@@ -9,6 +9,7 @@ mod proof;
 
 pub use proof::{
     gen_and_verify_batch_proofs, gen_and_verify_chunk_proofs, gen_and_verify_normal_and_evm_proofs,
+    gen_and_verify_normal_proof,
 };
 
 pub const ASSETS_DIR: &str = "./test_assets";


### PR DESCRIPTION
### Summary

Suppose to call this function in mass-testing, and could use `CompressionCircuit` for further update.