### PR TITLE
Refactor integration tests

### DIFF
--- a/integration/src/test_util.rs
+++ b/integration/src/test_util.rs
@@ -31,7 +31,7 @@ pub fn parse_trace_path_from_mode(mode: &str) -> &'static str {
         "dao" => "./tests/traces/dao/dao-propose.json",
         "nft" => "./tests/traces/nft/mint.json",
         "sushi" => "./tests/traces/sushi/chef-withdraw.json",
-        _ => "./tests/traces/erc20/10_transfer.json",
+        _ => "./tests/extra_traces/new.json",
     };
     log::info!("using mode {:?}, testing with {:?}", mode, trace_path);
     trace_path
@@ -41,7 +41,7 @@ pub fn load_block_traces_for_test() -> (Vec<String>, Vec<BlockTrace>) {
     let trace_path: String = read_env_var("TRACE_PATH", "".to_string());
     let paths: Vec<String> = if trace_path.is_empty() {
         // use mode
-        let mode = read_env_var("MODE", "multiple".to_string());
+        let mode = read_env_var("MODE", "default".to_string());
         if mode.to_lowercase() == "batch" || mode.to_lowercase() == "pack" {
             (1..=20)
                 .map(|i| format!("tests/traces/bridge/{i:02}.json"))

--- a/integration/tests/chunk_tests.rs
+++ b/integration/tests/chunk_tests.rs
@@ -13,7 +13,6 @@ fn test_chunk_prove_verify() {
     let output_dir = init_env_and_log("chunk_tests");
     log::info!("Initialized ENV and created output-dir {output_dir}");
 
-    env::set_var("TRACE_PATH", "./tests/extra_traces/new.json");
     let chunk_trace = load_block_traces_for_test().1;
     log::info!("Loaded chunk trace");
 

--- a/integration/tests/inner_tests.rs
+++ b/integration/tests/inner_tests.rs
@@ -1,0 +1,29 @@
+use integration::test_util::{load_block_traces_for_test, PARAMS_DIR};
+use prover::{
+    inner::{Prover, Verifier},
+    utils::init_env_and_log,
+    zkevm::circuit::SuperCircuit,
+};
+
+#[cfg(feature = "prove_verify")]
+#[test]
+fn test_inner_prove_verify() {
+    let test_name = "inner_tests";
+    let output_dir = init_env_and_log(test_name);
+    log::info!("Initialized ENV and created output-dir {output_dir}");
+
+    let chunk_trace = load_block_traces_for_test().1;
+    log::info!("Loaded chunk trace");
+
+    let mut prover = Prover::<SuperCircuit>::from_params_dir(PARAMS_DIR);
+    log::info!("Constructed prover");
+
+    let proof = prover
+        .load_or_gen_inner_proof(test_name, "inner", chunk_trace, Some(&output_dir))
+        .unwrap();
+    log::info!("Got inner snark");
+
+    let verifier = Verifier::<SuperCircuit>::from_params_dir(PARAMS_DIR, None);
+    assert!(verifier.verify_inner_snark(proof.to_snark()));
+    log::info!("Finish inner snark verification");
+}

--- a/integration/tests/integration.rs
+++ b/integration/tests/integration.rs
@@ -3,12 +3,11 @@ use halo2_proofs::{
     poly::commitment::Params,
 };
 use integration::test_util::{
-    ccc_by_chunk, load_block_traces_for_test, parse_trace_path_from_mode,
-    prepare_circuit_capacity_checker, run_circuit_capacity_checker, PARAMS_DIR,
+    load_block_traces_for_test, parse_trace_path_from_mode, prepare_circuit_capacity_checker,
+    run_circuit_capacity_checker, PARAMS_DIR,
 };
 use prover::{
     config::INNER_DEGREE,
-    inner::{Prover, Verifier},
     io::serialize_vk,
     utils::{get_block_trace_from_file, init_env_and_log, load_params, short_git_version},
     zkevm::circuit::{block_traces_to_witness_block, SuperCircuit, TargetCircuit},
@@ -64,7 +63,6 @@ fn test_cs_same_for_vk_consistent() {
     assert!(pk.get_vk().cs() == vk.cs(), "Real super circuit");
 }
 
-// TODO: move to prover of zkevm-circuits.
 #[test]
 fn test_capacity_checker() {
     init_env_and_log("integration");
@@ -90,20 +88,6 @@ fn estimate_circuit_rows() {
     log::info!("estimating used rows for batch");
     let rows = SuperCircuit::estimate_rows(&block_trace);
     log::info!("super circuit: {:?}", rows);
-}
-
-#[cfg(feature = "prove_verify")]
-#[test]
-fn test_mock_prove() {
-    init_env_and_log("integration");
-    let block_traces = load_block_traces_for_test().1;
-    Prover::<SuperCircuit>::mock_prove_target_circuit_batch(&block_traces).unwrap();
-}
-
-#[cfg(feature = "prove_verify")]
-#[test]
-fn test_inner_prove_verify() {
-    test_target_circuit_prove_verify::<SuperCircuit>();
 }
 
 #[cfg(feature = "prove_verify")]
@@ -206,25 +190,4 @@ fn test_vk_same() {
         }
     }
     assert_eq!(vk_empty_bytes, vk_real_bytes);
-}
-
-fn test_target_circuit_prove_verify<C: TargetCircuit>() {
-    let test_name = "inner_tests";
-    let output_dir = init_env_and_log(test_name);
-    log::info!("Initialized ENV and created output-dir {output_dir}");
-
-    let chunk_trace = load_block_traces_for_test().1;
-    log::info!("Loaded chunk trace");
-
-    let mut prover = Prover::<C>::from_params_dir(PARAMS_DIR);
-    log::info!("Constructed prover");
-
-    let proof = prover
-        .load_or_gen_inner_proof(test_name, "inner", chunk_trace, Some(&output_dir))
-        .unwrap();
-    log::info!("Got inner snark");
-
-    let verifier = Verifier::<C>::from_params_dir(PARAMS_DIR, None);
-    assert!(verifier.verify_inner_snark(proof.to_snark()));
-    log::info!("Finish inner snark verification");
 }

--- a/integration/tests/mock_tests.rs
+++ b/integration/tests/mock_tests.rs
@@ -1,0 +1,11 @@
+use integration::test_util::load_block_traces_for_test;
+use prover::{inner::Prover, utils::init_env_and_log, zkevm::circuit::SuperCircuit};
+
+#[cfg(feature = "prove_verify")]
+#[test]
+fn test_mock_prove() {
+    init_env_and_log("mock_tests");
+
+    let block_traces = load_block_traces_for_test().1;
+    Prover::<SuperCircuit>::mock_prove_target_circuit_batch(&block_traces).unwrap();
+}


### PR DESCRIPTION
### Summary

- delete hardcode of `new.json` trace in chunk-tests (which causes wrong test on chunk-234914).
- set `./tests/extra_traces/new.json` as default test trace (it could also be set by ENV `TRACE_PATH`).
- move inner-prove and move-prove to separate files.