### PR TITLE
fix: add `solc` install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 ### Prerequisite
 
+Install Solidity compiler `solc` of version `0.8.19` via [svm-rs](https://github.com/alloy-rs/svm-rs):
+```shell
+cargo install svm-rs
+svm install 0.8.19
+```
+
 Fetch git-submodule of test traces
 ```shell
 git submodule init


### PR DESCRIPTION
Related issue https://github.com/scroll-tech/scroll-prover/issues/284