### PR TITLE
Agg circuit parameters tunning 

### DIFF
--- a/integration/configs/layer2.config
+++ b/integration/configs/layer2.config
@@ -1,14 +1,14 @@
 {
   "strategy": "Simple",
-  "degree": 24,
+  "degree": 25,
   "num_advice": [
-    2
+    1
   ],
   "num_lookup_advice": [
-    2
+    1
   ],
   "num_fixed": 1,
-  "lookup_bits": 20,
+  "lookup_bits": 24,
   "limb_bits": 88,
   "num_limbs": 3
 }

--- a/integration/configs/layer3.config
+++ b/integration/configs/layer3.config
@@ -1,14 +1,14 @@
 {
   "strategy": "Simple",
-  "degree": 20,
+  "degree": 21,
   "num_advice": [
-    59
+    100
   ],
   "num_lookup_advice": [
-    7
+    14
   ],
   "num_fixed": 2,
-  "lookup_bits": 18,
+  "lookup_bits": 20,
   "limb_bits": 88,
   "num_limbs": 3
 }

--- a/integration/configs/layer3.config
+++ b/integration/configs/layer3.config
@@ -2,10 +2,10 @@
   "strategy": "Simple",
   "degree": 21,
   "num_advice": [
-    100
+    63
   ],
   "num_lookup_advice": [
-    14
+    8
   ],
   "num_fixed": 2,
   "lookup_bits": 20,

--- a/integration/configs/layer4.config
+++ b/integration/configs/layer4.config
@@ -5,10 +5,10 @@
     2
   ],
   "num_lookup_advice": [
-    2
+    1
   ],
-  "num_fixed": 2,
-  "lookup_bits": 20,
+  "num_fixed": 1,
+  "lookup_bits": 25,
   "limb_bits": 88,
   "num_limbs": 3
 }


### PR DESCRIPTION
- layer2: increase deg from 2^24 to 2^25 and reduce 2 advice polys to 1.
- layer3: increase deg from 2^20 to 2^21 and increase snark-verifier advice polys from 59 to 63.
- layer4: reduce num of lookup advice columns from 2 to 1.

Final verification cost is around 370k.