### PR TITLE
Update test_util.rs by using result and collect_paths function

### DIFF
--- a/integration/src/test_util.rs
+++ b/integration/src/test_util.rs
@@ -1,6 +1,9 @@
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
+use anyhow::{Context, Result};
 use glob::glob;
+use log::info;
 use prover::{
     utils::{get_block_trace_from_file, read_env_var},
     BlockTrace,
@@ -19,56 +22,69 @@ pub const ASSETS_DIR: &str = "./test_assets";
 pub const PARAMS_DIR: &str = "./params";
 
 pub fn load_chunk_for_test() -> (Vec<String>, Vec<BlockTrace>) {
-    let trace_path: String = read_env_var(
+    let trace_path = read_env_var(
         "TRACE_PATH",
         "./tests/extra_traces/batch_495/chunk_495/block_8802.json".to_string(),
     );
-    load_chunk(&trace_path)
+    load_chunk(&trace_path).unwrap()
 }
 
-pub fn load_chunk(trace_path: &str) -> (Vec<String>, Vec<BlockTrace>) {
-    let paths: Vec<String> = if !std::fs::metadata(trace_path).unwrap().is_dir() {
-        vec![trace_path.to_string()]
-    } else {
-        // Nested dirs are not allowed
-        let mut file_names: Vec<String> = glob(&format!("{trace_path}/*.json"))
+pub fn load_chunk(trace_path: &str) -> Result<(Vec<String>, Vec<BlockTrace>)> {
+    let paths = collect_paths(trace_path)?;
+    info!("test cases traces: {:?}", paths);
+    let traces: Vec<_> = paths.iter().map(|path| get_block_trace_from_file(path)).collect();
+    Ok((paths, traces))
+}
+
+fn collect_paths(trace_path: &str) -> Result<Vec<String>> {
+    let path = Path::new(trace_path);
+    if !path.is_dir() {
+        return Ok(vec![trace_path.to_string()]);
+    }
+
+    let mut file_names: Vec<String> = glob(&format!("{}/*.json", trace_path))
+        .context("Failed to read glob pattern")?
+        .filter_map(Result::ok)
+        .map(|p| p.to_str().unwrap().to_string())
+        .collect();
+
+    file_names.sort_by_key(|s| {
+        Path::new(s)
+            .file_stem()
             .unwrap()
-            .map(|p| p.unwrap().to_str().unwrap().to_string())
-            .collect();
-        file_names.sort_by_key(|s| {
-            let path = Path::new(s);
-            let basename = path.file_stem().unwrap().to_str().unwrap();
-            basename
-                .trim_start_matches("block_")
-                .parse::<u32>()
-                .unwrap()
-        });
-        file_names
-    };
-    log::info!("test cases traces: {:?}", paths);
-    let traces: Vec<_> = paths.iter().map(get_block_trace_from_file).collect();
-    (paths, traces)
+            .to_str()
+            .unwrap()
+            .trim_start_matches("block_")
+            .parse::<u32>()
+            .unwrap()
+    });
+
+    Ok(file_names)
 }
 
-pub fn load_batch(batch_dir: &str) -> anyhow::Result<Vec<String>> {
-    let mut sorted_dirs: Vec<String> = std::fs::read_dir(batch_dir)?
-        .filter_map(|entry| entry.ok())
+pub fn load_batch(batch_dir: &str) -> Result<Vec<String>> {
+    let mut sorted_dirs: Vec<String> = fs::read_dir(batch_dir)?
+        .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_dir())
         .map(|path| path.to_string_lossy().into_owned())
-        .collect::<Vec<String>>();
+        .collect();
+
     sorted_dirs.sort_by_key(|s| {
-        let path = Path::new(s);
-        let dir_name = path.file_name().unwrap().to_string_lossy();
-        dir_name
+        Path::new(s)
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
             .trim_start_matches("chunk_")
             .parse::<u32>()
             .unwrap()
     });
-    let fast = false;
+
+    let fast = false;  // Consider making this a parameter if configurable
     if fast {
         sorted_dirs.truncate(1);
     }
-    log::info!("batch content: {:?}", sorted_dirs);
+
+    info!("batch content: {:?}", sorted_dirs);
     Ok(sorted_dirs)
 }


### PR DESCRIPTION
Use the Result type and the anyhow crate for error handling, which is more robust than using unwrap. Using Result ensures that errors are handled gracefully, providing clear context and messages when something goes wrong. This avoids the potential for the application to panic unexpectedly, leading to better stability and reliability.

Auxiliary Functions
I have separated the file path collection into the collect_paths function. This refactoring improves the previous code by enhancing modularity and readability. By isolating the logic for path collection, the main functions (load_chunk and load_batch) become cleaner and easier to understand. This separation of concerns makes the code more maintainable and allows for easier testing and debugging of individual components.