### PR TITLE
Update prove.rs

### DIFF
--- a/integration/src/test_util/prove.rs
+++ b/integration/src/test_util/prove.rs
@@ -59,5 +59,5 @@ pub fn prove_and_verify_batch(
     assert!(verifier.verify_agg_evm_proof(batch_proof));
     log::info!("Verified batch proof");
 
-    log::info!("Prove batch END: chunk_num = {chunk_num}");
+    log::info!("Prove batch BEGIN: chunk_num = {}", chunk_num);
 }


### PR DESCRIPTION
In Rust, string interpolation is done using curly braces {} to indicate where the values should be inserted into the string. In this code, we are attempting to interpolate the value of chunk_num into the log message.

Here's the incorrect line:

log::info!("Prove batch BEGIN: chunk_num = {chunk_num}");

And the correct line is : 

log::info!("Prove batch BEGIN: chunk_num = {}", chunk_num);