### PR TITLE
[Refactor] Verifier for compression circuit

### DIFF
--- a/integration/src/lib.rs
+++ b/integration/src/lib.rs
@@ -2,3 +2,4 @@ pub mod capacity_checker;
 pub mod evm;
 pub mod prove;
 pub mod test_util;
+mod verifier;

--- a/integration/src/prove.rs
+++ b/integration/src/prove.rs
@@ -1,8 +1,7 @@
-use crate::test_util::PARAMS_DIR;
+use crate::{test_util::PARAMS_DIR, verifier::*};
 use prover::{
-    aggregator::{Prover as BatchProver, Verifier as BatchVerifier},
-    zkevm::{Prover as ChunkProver, Verifier as ChunkVerifier},
-    BatchProof, BatchProvingTask, BundleProvingTask, ChunkProvingTask,
+    aggregator::Prover as BatchProver, zkevm::Prover as ChunkProver, BatchProof, BatchProvingTask,
+    BundleProvingTask, ChunkProvingTask,
 };
 use std::{env, time::Instant};
 
@@ -36,8 +35,8 @@ pub fn prove_and_verify_chunk(
 
     // output_dir is used to load chunk vk
     env::set_var("CHUNK_VK_FILENAME", "vk_chunk_0.vkey");
-    let verifier = ChunkVerifier::from_dirs(params_path, output_dir);
-    assert!(verifier.verify_chunk_proof(chunk_proof));
+    let verifier = new_chunk_verifier(params_path, output_dir);
+    assert!(verifier.verify_snark(chunk_proof.to_snark()));
     log::info!("Verified chunk proof");
 }
 
@@ -54,10 +53,10 @@ pub fn prove_and_verify_batch(
         .unwrap();
 
     env::set_var("BATCH_VK_FILENAME", "vk_batch_agg.vkey");
-    let verifier = BatchVerifier::from_dirs(PARAMS_DIR, output_dir);
+    let verifier = new_batch_verifier(PARAMS_DIR, output_dir);
     log::info!("Constructed aggregator verifier");
 
-    assert!(verifier.verify_batch_proof(&batch_proof));
+    assert!(verifier.verify_snark((&batch_proof).into()));
     log::info!("Verified batch proof");
 
     log::info!("Prove batch END: chunk_num = {chunk_num}");
@@ -76,11 +75,11 @@ pub fn prove_and_verify_bundle(
         .gen_bundle_proof(bundle, None, Some(output_dir))
         .unwrap();
 
-    env::set_var("BATCH_VK_FILENAME", "vk_batch_agg.vkey");
-    let verifier = BatchVerifier::from_dirs(PARAMS_DIR, output_dir);
+    env::set_var("BATCH_VK_FILENAME", "vk_bundle_recursion.vkey");
+    let verifier = EVMVerifier::from_dirs(output_dir);
     log::info!("Constructed bundle verifier");
 
-    assert!(verifier.verify_bundle_proof(bundle_proof));
+    assert!(verifier.verify_evm_proof(bundle_proof.calldata()));
     log::info!("Verifier bundle proof");
 
     log::info!("Prove bundle END");

--- a/integration/src/verifier.rs
+++ b/integration/src/verifier.rs
@@ -1,0 +1,34 @@
+use prover::{common::Verifier, config, consts, io::force_to_read, CompressionCircuit};
+use snark_verifier_sdk::verify_evm_calldata;
+use std::env;
+
+type SnarkVerifier = Verifier<CompressionCircuit>;
+
+pub fn new_chunk_verifier(params_dir: &str, assets_dir: &str) -> SnarkVerifier {
+    let raw_vk = force_to_read(assets_dir, &consts::chunk_vk_filename());
+    env::set_var("COMPRESSION_CONFIG", &*config::LAYER2_CONFIG_PATH);
+    SnarkVerifier::from_params_dir(params_dir, *config::LAYER2_DEGREE, &raw_vk)
+}
+
+pub fn new_batch_verifier(params_dir: &str, assets_dir: &str) -> SnarkVerifier {
+    let raw_vk = force_to_read(assets_dir, &consts::batch_vk_filename());
+    env::set_var("COMPRESSION_CONFIG", &*config::LAYER4_CONFIG_PATH);
+    SnarkVerifier::from_params_dir(params_dir, *config::LAYER4_DEGREE, &raw_vk)
+}
+
+#[derive(Debug)]
+pub struct EVMVerifier(Vec<u8>);
+
+impl EVMVerifier {
+    pub fn new(deployment_code: Vec<u8>) -> Self {
+        Self(deployment_code)
+    }
+
+    pub fn from_dirs(assets_dir: &str) -> Self {
+        Self::new(force_to_read(assets_dir, &consts::DEPLOYMENT_CODE_FILENAME))
+    }
+
+    pub fn verify_evm_proof(&self, call_data: Vec<u8>) -> bool {
+        verify_evm_calldata(self.0.clone(), call_data)
+    }
+}


### PR DESCRIPTION
## Reason

The config for `layer6` has been optimized so it is now different with `layer4`. Notice [the `Verifier` for aggregator always make use a config from layer4](https://github.com/scroll-tech/zkevm-circuits/blob/c534681bf35554357bf80cf565f8fdbaa33eec9b/prover/src/aggregator/verifier.rs#L43), it cause an error while loading the vkey generated in bundle circuit (with config of `layer6`).

This has exlained why [this commit](https://github.com/scroll-tech/scroll-prover/commit/527476b10f9255a33b98b7d1853cb6dfaa0c908a) has to rename the loaded vkey to make it pass e2e test: it would fail if it actually load the vkey for bundle circuit (configured by `layer6`) but would pass if it just load vkey for batch circuit again. Also, for verifier verifing for final layer (bundle) do not use the vkey it loaded.

But such a hack has broken the `test-bundle-prove` unittest.

So we have to refactor and separate the verifer for each circuit.

## Refactoring

Notice that all the verifier just verify the proof from `CompressionCircuit`, it would be convenient to reorganize them into two type of verifier: for "immediate" layer and for final layer. Note that the proof for final layer use keccak of transcript to set up its challenge, so it can not be handled by the common verify entry in `snark-verifier-sdk`, which use poseidon hash of transcript for challenge.

This PR just made a refactoring for the integration tests. The logic inside `zkevm-circuit` should still work while being referred by libzkp.